### PR TITLE
Fix tor-socat NAT issue by listening on port 53

### DIFF
--- a/deb/custom-dns-deb
+++ b/deb/custom-dns-deb
@@ -35,12 +35,6 @@ EOF
   fi
 fi
 
-### 3) Add iptables‐NAT rules to redirect all DNS to port 2053
-# (glibc always sends to port 53; we catch it and forward to 2053)
-for proto in udp tcp; do
-  if ! iptables -t nat -C OUTPUT -p $proto --dport 53 -j REDIRECT --to-ports 2053 2>/dev/null; then
-    iptables -t nat -A OUTPUT -p $proto --dport 53 -j REDIRECT --to-ports 2053
-  fi
-done
+### 3) No iptables redirection needed, Pi-hole now binds directly to port 53
 
-echo "✅ System-wide DNS now forced to 127.0.0.1:2053"
+echo "✅ System-wide DNS now points to 127.0.0.1:53"

--- a/deb/custom-dns-deb.service
+++ b/deb/custom-dns-deb.service
@@ -1,5 +1,5 @@
 [Unit]
-Description=Force system-wide DNS to 127.0.0.1:2053
+Description=Configure system DNS to use 127.0.0.1:53
 After=network.target
 Wants=network-online.target
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -40,9 +40,9 @@ services:
     container_name: pi-hole
     build: pihole/
     ports:
-      - 2053:53/tcp
-      - 2053:53/udp
-      - ${WEBPORT}:80      
+      - 53:53/tcp
+      - 53:53/udp
+      - ${WEBPORT}:80
     networks:
       dnsnet:
         ipv4_address: 172.31.240.250

--- a/install-deb.sh
+++ b/install-deb.sh
@@ -5,6 +5,7 @@
 if [ "$(podman ps -a | grep -c "tor-socat\|unbound\|pi-hole")" -gt 0 ]
   then
     #Remove them if exist
+    # Clean up legacy iptables redirection rules from older versions
     for proto in udp tcp; do
       if iptables -t nat -C OUTPUT -p $proto --dport 53 -j REDIRECT --to-ports 2053 2>/dev/null; then
         sudo iptables -t nat -D OUTPUT -p $proto --dport 53 -j REDIRECT --to-ports 2053

--- a/mac/dns-mac.sh
+++ b/mac/dns-mac.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-# setup-local-dns.sh — idempotent setup for macOS to redirect all DNS → 127.0.0.1:2053
+# setup-local-dns.sh — idempotent setup for macOS to use local DNS at 127.0.0.1
 
 set -euo pipefail
 
@@ -23,11 +23,18 @@ networksetup -listallnetworkservices |\
       networksetup -setdnsservers "$SERVICE" 127.0.0.1 >/dev/null
     done
 
-# 3. Create PF anchor file
-echo "🔧 Ensuring PF anchor ${ANCHOR_FILE} exists..."
-cat > "$ANCHOR_FILE" <<EOF
-rdr pass inet proto { tcp, udp } from any to 127.0.0.1 port 53 -> 127.0.0.1 port 2053
-EOF
-echo " • Wrote redirect rule to $ANCHOR_FILE"
 
-echo "🎉 All done! Your system will now send every DNS query → 127.0.0.1:2053"
+# 3. Remove any old PF redirect rule (if present)
+if [ -f "$ANCHOR_FILE" ]; then
+  rm -f "$ANCHOR_FILE"
+  echo "🔧 Removed obsolete PF anchor $ANCHOR_FILE"
+fi
+
+if grep -q "anchor \"${ANCHOR_NAME}\"" "$PF_CONF"; then
+  sed -i '' "/anchor \"${ANCHOR_NAME}\"/d" "$PF_CONF"
+  echo "🔧 Cleaned anchor reference from $PF_CONF"
+fi
+
+pfctl -f "$PF_CONF" >/dev/null 2>&1 || true
+
+echo "🎉 All done! Your system will now send every DNS query → 127.0.0.1:53"


### PR DESCRIPTION
## Summary
- expose Pi-hole directly on port 53
- remove iptables redirection from `custom-dns-deb`
- update service file and mac helper script
- cleanup leftover iptables rule in installer

## Testing
- `bash -n deb/custom-dns-deb`
- `bash -n mac/dns-mac.sh`
- `bash -n install-deb.sh`
- `podman --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685b0fc7a4a48331982d29e45e84ee8c