### PR TITLE
Add compose dependency order

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -29,6 +29,9 @@ services:
   unbound:
     container_name: unbound
     build: unbound/
+    depends_on:
+      tor-socat:
+        condition: service_healthy
     networks:
       dnsnet:
         ipv4_address: 172.31.240.251
@@ -39,6 +42,9 @@ services:
   pi-hole:
     container_name: pi-hole
     build: pihole/
+    depends_on:
+      unbound:
+        condition: service_healthy
     ports:
       - 53:53/tcp
       - 53:53/udp


### PR DESCRIPTION
## Summary
- add depends_on to ensure unbound waits for tor-socat
- ensure pi-hole waits for unbound

## Testing
- `docker compose config` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685b1991be68833192f90e96c50fffdc