### PR TITLE
Remove obsolete Ubuntu cleanup

### DIFF
--- a/install-deb.sh
+++ b/install-deb.sh
@@ -9,11 +9,6 @@ if [[ $EUID -eq 0 ]]; then
   exit 1
 fi
 
-# Clean up legacy iptables redirection rules from older versions
-for proto in udp tcp; do
-    sudo iptables -t nat -D OUTPUT -p $proto --dport 53 -j REDIRECT --to-ports 2053
-done
-sudo netfilter-persistent save
 
 #Check if there are installed previous versions
 if [ "$(podman ps -a | grep -c "tor-socat\|unbound\|pi-hole")" -gt 0 ]


### PR DESCRIPTION
## Summary
- remove old iptables cleanup from install script

## Testing
- `shellcheck install-deb.sh`
- `bash -n install-deb.sh`

------
https://chatgpt.com/codex/tasks/task_e_6873e961f50c8331903b0a36fb625b5f